### PR TITLE
Fix Configuration

### DIFF
--- a/lib/lets_encrypt_heroku/acme_client.rb
+++ b/lib/lets_encrypt_heroku/acme_client.rb
@@ -36,7 +36,7 @@ module LetsEncryptHeroku
     private
 
     def client
-      @client ||= Acme::Client.new(private_key: private_key, endpoint: 'https://acme-v01.api.letsencrypt.org/')
+      @client ||= Acme::Client.new(private_key: private_key, endpoint: LetsEncryptHeroku.configuration.endpoint)
       registration = @client.register(contact: email)
       registration.agree_terms
       @client

--- a/lib/lets_encrypt_heroku/acme_client.rb
+++ b/lib/lets_encrypt_heroku/acme_client.rb
@@ -31,8 +31,6 @@ module LetsEncryptHeroku
     def request_certificates(domains)
       request = Acme::Client::CertificateRequest.new(names: domains)
       certificate = client.new_certificate(request)
-    rescue StandardError => e
-      binding.pry
     end
 
     private
@@ -45,8 +43,6 @@ module LetsEncryptHeroku
     rescue Acme::Client::Error::Malformed => e
       # TODO: log e.message, typically it is just that the registration key was previously registered
       @client
-    rescue StandardError => e
-      binding.pry
     end
 
   end

--- a/lib/lets_encrypt_heroku/configuration.rb
+++ b/lib/lets_encrypt_heroku/configuration.rb
@@ -8,14 +8,7 @@ module LetsEncryptHeroku
     attr_accessor :endpoint, :email, :domain, :private_key
 
     def initialize
-      @heroku_platform_api_token = ENV['HEROKU_PLATFORM_API_TOKEN']
-      @heroku_app_name = ENV['HEROKU_APP_NAME']
-      @heroku_ssl_name = ENV['HEROKU_SSL_NAME']
-
-      @endpoint = ENV['ENDPOINT']
-      @email = ENV['EMAIL']
-      @domain = ENV['DOMAIN']
-      @private_key = OpenSSL::PKey::RSA.new(ENV['PRIVATE_KEY']) if ENV['PRIVATE_KEY']
+      @endpoint = 'https://acme-v01.api.letsencrypt.org/'
     end
 
   end


### PR DESCRIPTION
This fix ensures `AcmeClient` uses the configured endpoint if one is specified. Otherwise, it defaults to the production endpoint.
Previously, it was hardcoded to the production endpoint which is bad when running tests.

Also, configuration is now left to the gem user and no longer auto-loaded from environment variables.
The README already contains instructions on how to do this.
